### PR TITLE
Add missing unfold(-right)! in reference implementation

### DIFF
--- a/shared-tests.scm
+++ b/shared-tests.scm
@@ -170,6 +170,16 @@
     (display "reverse-copy!\n")
     (s16vector-reverse-copy! v 1 s5 2 4)
     (test-equiv "reverse-copy!" '(10 4 3 40 50) v))
+  (let ((v (s16vector 1 2 3 4 5 6 7 8)))
+    (display "unfold!")
+    (s16vector-unfold! (lambda (x) (values (* x 2) (* x 2)))
+                       v 1 6 -1)
+    (test-equiv "vector-unfold!" '(1 -2 -4 -8 -16 -32 7 8) v))
+  (let ((v (s16vector 1 2 3 4 5 6 7 8)))
+    (display "unfold-right!")
+    (s16vector-unfold-right! (lambda (x) (values (* x 2) (* x 2)))
+                             v 1 6 -1)
+    (test-equiv "vector-unfold!" '(1 -32 -16 -8 -4 -2 7 8) v))
 ) ; end s16vector/mutators
 
 (test-group "s16vector/conversion"

--- a/srfi.160.at.scm
+++ b/srfi.160.at.scm
@@ -32,7 +32,8 @@
           @vector-filter @vector-remove)
   ;; Mutators 
   (export @vector-set! @vector-swap! @vector-fill! @vector-reverse!
-          @vector-copy! @vector-reverse-copy!)
+          @vector-copy! @vector-reverse-copy!
+          @vector-unfold! @vector-unfold-right!)
   ;; Conversion 
   (export @vector->list reverse-@vector->list reverse-list->@vector
           @vector->vector vector->@vector)

--- a/srfi/160/at-impl.scm
+++ b/srfi/160/at-impl.scm
@@ -455,6 +455,20 @@
         (@vector-swap! vec i j)
         (loop (+ i 1) (- j 1))))))
 
+(define (@vector-unfold! f vec start end seed)
+  (let loop ((i start) (seed seed))
+    (when (< i end)
+      (let-values (((elt seed) (f seed)))
+        (@vector-set! vec i elt)
+        (loop (+ i 1) seed)))))
+
+(define (@vector-unfold-right! f vec start end seed)
+  (let loop ((i (- end 1)) (seed seed))
+    (when (>= i start)
+      (let-values (((elt seed) (f seed)))
+        (@vector-set! vec i elt)
+        (loop (- i 1) seed)))))
+
 (define reverse-@vector->list
   (case-lambda
     ((vec) (reverse-@vector->list* vec 0 (@vector-length vec)))

--- a/srfi/160/at.sld
+++ b/srfi/160/at.sld
@@ -32,7 +32,8 @@
           @vector-filter @vector-remove)
   ;; Mutators 
   (export @vector-set! @vector-swap! @vector-fill! @vector-reverse!
-          @vector-copy! @vector-reverse-copy!)
+          @vector-copy! @vector-reverse-copy!
+          @vector-unfold! @vector-unfold-right!)
   ;; Conversion 
   (export @vector->list reverse-@vector->list reverse-list->@vector
           @vector->vector vector->@vector)


### PR DESCRIPTION
@vector-unfold! and @vector-unfold-right! are added in last minute and missing reference implementation.  This PR adds them, along the tests.
