### PR TITLE
Missing export list->@vector

### DIFF
--- a/srfi/160/at.sld
+++ b/srfi/160/at.sld
@@ -35,7 +35,8 @@
           @vector-copy! @vector-reverse-copy!
           @vector-unfold! @vector-unfold-right!)
   ;; Conversion 
-  (export @vector->list reverse-@vector->list reverse-list->@vector
+  (export @vector->list list->@vector
+          reverse-@vector->list reverse-list->@vector
           @vector->vector vector->@vector)
   ;; Misc
   (export make-@vector-generator @vector-comparator write-@vector)


### PR DESCRIPTION
For some reason the `list->@vector` procedure was omitted from the exports list.  The commit history is a little messy; I thought the implementation was missing too, but it's in `(srfi 160 base)`.  So everything cancels out except the change to `srfi/160/at.sld`.