### PR TITLE
Add SPDX license/copyright metadata to all source files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 # Chicken compiler artifacts
 srfi.160.base.import.scm
 srfi.160.s16.import.scm

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,10 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: SRFI 160
+Upstream-Contact: Arthur A. Gleckler <srfi-editors@srfi.schemers.org>
+Source: https://github.com/scheme-requests-for-implementation/srfi-160
+
+# Sample paragraph, commented out:
+#
+# Files: src/*
+# Copyright: $YEAR $NAME <$CONTACT>
+# License: ...

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.org
+++ b/README.org
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 * SRFI 160: Homogeneous numeric vector libraries
 
 ** by John Cowan and Shiro Kawai (contributed a major patch)

--- a/atexpander.sh
+++ b/atexpander.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+#
+# SPDX-License-Identifier: MIT
+
 # Expand library, implementation and test files
 for at in u8 s8 u16 s16 u32 s32 u64 s64 f32 f64 c64 c128; do
     sed "s/@/$at/g" srfi/160/at.sld >srfi/160/$at.sld

--- a/chibi-base-tests.scm
+++ b/chibi-base-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base))
 (import (scheme write))
 (import (scheme complex))

--- a/chibi-tests.scm
+++ b/chibi-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; Chibi tests for s16vectors (if one vector type works, they all work)
 (import (scheme base))
 (import (scheme write))

--- a/chicken-base-tests.scm
+++ b/chicken-base-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme))
 (import (srfi 160 base))
 

--- a/chicken-tests.scm
+++ b/chicken-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; Chicken Tests for s16vectors (if one vector type works, they all work)
 (import (scheme))
 (import (test))

--- a/gauche-tests.scm
+++ b/gauche-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (use gauche.test)
 (use compat.chibi-test)
 (add-load-path "." :relative)

--- a/include.scm
+++ b/include.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (library (include)
   (export include)
   (import (rnrs base)

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 Arthur A. Gleckler <srfi@speechcode.com>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/shared-base-tests.scm
+++ b/shared-base-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; Shared tests
 ;;; Hvector = homogeneous vector
 

--- a/shared-tests.scm
+++ b/shared-tests.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define (times2 x) (* x 2))
 (define s5 (s16vector 1 2 3 4 5))
 (define s4 (s16vector 1 2 3 4))

--- a/srfi-160.html
+++ b/srfi-160.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
   <head>

--- a/srfi.160.at.scm
+++ b/srfi.160.at.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (module (srfi 160 @) ()
   (import (scheme))
   (import (only (chicken base)

--- a/srfi.160.base.scm
+++ b/srfi.160.base.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (module (srfi 160 base) ()
   (import (scheme))
   (import (only (chicken base) include define-record-type case-lambda))

--- a/srfi/160/at-impl.scm
+++ b/srfi/160/at-impl.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;; This code is the same for all SRFI 160 vector sizes.
 ;;; The @s appearing in the code are expanded to u8, s8, etc.
 

--- a/srfi/160/at.sld
+++ b/srfi/160/at.sld
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define-library (srfi 160 @)
   (import (scheme base))
   (import (scheme case-lambda))

--- a/srfi/160/base.sld
+++ b/srfi/160/base.sld
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define-library (srfi 160 base)
   (import (scheme base))
   (import (scheme case-lambda))

--- a/srfi/160/base/at-vector2list.scm
+++ b/srfi/160/base/at-vector2list.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; Implementation of SRFI 160 base @vector->list
 
 (define @vector->list

--- a/srfi/160/base/complex.scm
+++ b/srfi/160/base/complex.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;;;; Implementation of SRFI 160 base c64vectors and c128vectors
 
 ;;; Main constructor

--- a/srfi/160/base/r6rec.scm
+++ b/srfi/160/base/r6rec.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;; The representation of complex vectors
 
 (define-record-type (<c64vector> raw-make-c64vector c64vector?)

--- a/srfi/160/base/r7rec.scm
+++ b/srfi/160/base/r7rec.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ;; The representation of complex vectors
 
 (define-record-type <c64vector> (raw-make-c64vector bv) c64vector?

--- a/srfi/160/base/valid.scm
+++ b/srfi/160/base/valid.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define (u8? n) (and (exact-integer? n) (<= 0 n 255)))
 
 (define (s8? n) (and (exact-integer? n) (<= -128 n 127)))

--- a/unexpander.sh
+++ b/unexpander.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# SPDX-FileCopyrightText: 2018 John Cowan <cowan@ccil.org>
+#
+# SPDX-License-Identifier: MIT
+
 # Remove expanded library, implementation and test files
 for at in u8 s8 u16 s16 u32 s32 u64 s64 f32 f64 c64 c128; do
     rm -f srfi/160/$at.sld


### PR DESCRIPTION
This will make it extra clear what are the copying conditions for downstream users wanting to distribute these library files.